### PR TITLE
Get interface through packet_source() bif instead of cluster layout

### DIFF
--- a/scripts/add-interfaces.zeek
+++ b/scripts/add-interfaces.zeek
@@ -1,4 +1,4 @@
-##! Adds cluster node's interface to logs.
+##! Adds node's interface to logs.
 
 module AddInterfaces;
 
@@ -11,7 +11,7 @@ export {
 	const include_logs: set[Log::ID] = { Conn::LOG } &redef;
 }
 
-@if ( Cluster::is_enabled() )
+global my_interface: string;
 
 type AddedFields: record {
 	interface: string &log;
@@ -19,14 +19,28 @@ type AddedFields: record {
 
 function interface_ext_func(path: string): AddedFields
 	{
-	if ( Cluster::nodes[Cluster::node]?$interface )
-		return AddedFields($interface = Cluster::nodes[Cluster::node]$interface);
-	else
-		return AddedFields($interface = fmt("%s:unknown-interface", Cluster::node));
+	return AddedFields($interface=my_interface);
 	}
 
 event zeek_init() &priority=-3
 	{
+	local ps = packet_source();
+	if ( ps?$live && ps$live && ps?$path )
+		my_interface = ps$path;
+
+	# This is backwards compat such that non-workers within a
+	# cluster add "<node>:unknown-interface" to log entries
+	# they generate. It's the only reason we depend on the
+	# cluster framework at this point.
+	if ( |my_interface| == 0 && Cluster::is_enabled() )
+		my_interface = fmt("%s:unknown-interface", Cluster::node);
+
+	if ( |my_interface| == 0 )
+		{
+		Reporter::warning("Interfaces are not added to logs!");
+		return;
+		}
+
 	# Add ext_func to log streams
 	for ( id in Log::active_streams )
 		{
@@ -38,12 +52,3 @@ event zeek_init() &priority=-3
 			}
 		}
 	}
-
-@else
-
-event zeek_init()
-	{
-	Reporter::warning("Interfaces are not added to logs (not in cluster mode)!");
-	}
-
-@endif


### PR DESCRIPTION
Zeek 3.1 introduced the packet_source() bif. It can be leveraged to reliably get the live interface of a worker. Whether cluster-layout.zeek / Cluster::nodes provides the interface field is not guaranteed.

This change allows to use this package in environments where the Cluster::Node$interface field is not populated. Further, it adds the interface for a simple `zeek -i eth0` invocation which seems nice.

Technically, the only reason this depends on Cluster now is the fallback to the "unknown" interface and I'm not quite sure that's actually useful for when logs are generated on proxies or managers.